### PR TITLE
Add lead scoring prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # company-evaluator
+
+This repository explores how to score potential B2B leads for **[Fineguide.ai](https://fineguide.ai)**, a platform that provides enterprise-grade AI agents for customer service. The goal is to estimate how likely a given company is to purchase or trial Fineguide's services.
+
+## Fineguide snapshot
+- Website title: *"Fineguide.ai | AI platform for customer service"*
+- Tagline: *"Smarter AI Agents for Real Results"*
+- Description: *"Fineguide.ai delivers enterprise-grade AI agents that understand complex customer inquiries, provide accurate responses and drive measurable outcomes."*
+
+_Source: [fineguide.ai](https://fineguide.ai)_
+
+## Scoring approach
+1. **Target** – Predict whether a company will meaningfully trial or buy Fineguide within the next 6 months.
+2. **Signals** – Extract signals across six buckets:
+   - Fit to ICP (industry, company size, traffic, support team size)
+   - Pain indicators (support job posts, help center size)
+   - AI/digital maturity (mentions of chatbots, existing support tech)
+   - Buying intent (funding events, AI webinars, search activity)
+   - Budget & authority (revenue, decision makers)
+   - Timing triggers (seasonal peaks, new launches)
+3. **Pipeline** – For each company:
+   - Enrich data via web scraping and APIs (BuiltWith, SERP search, LinkedIn).
+   - Use an OpenAI model (via LangChain) to score each bucket 0‑5 based on gathered context.
+   - Aggregate weighted scores into a 0‑100 likelihood to buy.
+   - Store results for sales review and feedback.
+
+See `scorer.py` for a minimal LangChain prototype.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+langchain
+pydantic

--- a/scorer.py
+++ b/scorer.py
@@ -1,0 +1,61 @@
+"""Prototype scoring pipeline using LangChain and OpenAI."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from pydantic import BaseModel, Field
+from langchain_openai import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema.output_parser import PydanticOutputParser
+
+
+class Score(BaseModel):
+    """Structured scoring output."""
+
+    fit: int = Field(ge=0, le=5)
+    pain: int
+    ai_maturity: int
+    intent: int
+    budget_authority: int
+    timing: int
+    rationale: str
+    evidence: List[str]
+    final_score: int
+
+
+def build_chain(model: str = "gpt-3.5-turbo-0613"):
+    llm = ChatOpenAI(model=model, temperature=0)
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a B2B sales analyst scoring how likely a company is to buy AI agents from Fineguide.ai.",
+            ),
+            (
+                "user",
+                """Company: {name}\nWebsite text: {web_context}\nStructured data: {firmo}\nInstructions: Score each category 0-5 and explain. Return JSON only.""",
+            ),
+        ]
+    )
+
+    parser = PydanticOutputParser(pydantic_object=Score)
+    return prompt | llm | parser
+
+
+if __name__ == "__main__":
+    if "OPENAI_API_KEY" not in os.environ:
+        raise SystemExit("Please set the OPENAI_API_KEY environment variable")
+
+    chain = build_chain()
+
+    # Example usage with dummy data
+    result = chain.invoke(
+        {
+            "name": "Example Corp",
+            "web_context": "Example Corp provides 24/7 online retail services.",
+            "firmo": "Employees: 1000, Industry: e-commerce",
+        }
+    )
+    print(result.json())


### PR DESCRIPTION
## Summary
- document scoring approach for potential Fineguide.ai customers
- include example LangChain scoring pipeline
- list minimal requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688526058d0883279d1b4b9270cb6b1c